### PR TITLE
Make 8 double to fix a compilation error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Server.run(cfg) { s =>
   // a synth graph function in an `Out` element
   // and playing it back.
   play {
-    val f = LFSaw.kr(0.4).madd(24, LFSaw.kr(Seq(8, 7.23)).madd(3, 80)).midicps
+    val f = LFSaw.kr(0.4).madd(24, LFSaw.kr(Seq(8.0, 7.23)).madd(3, 80)).midicps
     CombN.ar(SinOsc.ar(f) * 0.04, 0.2, 0.2, 4)
   }
 }    


### PR DESCRIPTION
I believe this code was your intention. The previous has `8` which Scala regards as Integer and makes a compilation error.